### PR TITLE
Handle errors in save_existing

### DIFF
--- a/lib/her/model/orm.rb
+++ b/lib/her/model/orm.rb
@@ -147,7 +147,10 @@ module Her
         #   # Called via PUT "/users/1"
         def save_existing(id, params)
           resource = new(params.merge(primary_key => id))
-          resource.save
+          result = resource.save
+          if not result
+            raise Her::Errors::ResourceInvalid, resource
+          end
           resource
         end
 


### PR DESCRIPTION
The current behavior is to ignore errors and proceed as if the update didn't fail. This is not good as the users of the object won't know that their write failed and will assume that it was performed. Required by BST-1238